### PR TITLE
Add "curpos!" word, to set cursor position.

### DIFF
--- a/block31.fth
+++ b/block31.fth
@@ -13,5 +13,4 @@ create color 7 ,
 : attr! ( attr curpos -- ) dup hibyte #80 u* swap lobyte +
   2* 1+ vga! ;
 :noname ( c -- ) curpos@ over emit-tty swap printable? if
-  color @ swap attr! else drop then ; is emit
-                                                             -->
+  color @ swap attr! else drop then ; is emit                -->


### PR DESCRIPTION
Uses `int 10h` with AH=2. This is useful for some fun text formatting and display stuff. I feel like it's appropriate for block 31, right next to `curpos@`.

Copies the calling-convention of emit-tty above it. If something's amiss about this, feel free to make changes; I tested it on my end and it worked, but I'm something of an asm noob :)